### PR TITLE
Fix lost terminus stage text flickering

### DIFF
--- a/stripper/ze_lost_terminus_b4.cfg
+++ b/stripper/ze_lost_terminus_b4.cfg
@@ -1367,7 +1367,7 @@ add:
     "targetname" "chapter_gametext"
     "spawnflags" "1"
     "message" "???"
-    "holdtime" "9999"
+    "holdtime" "5"
     "fxtime" "0.25"
     "fadeout" "2"
     "fadein" "1.5"
@@ -1376,6 +1376,8 @@ add:
     "color" "255 0 0"
     "channel" "0"
     "classname" "game_text"
+    "OnUser1" "!selfDisplay0-1"
+    "OnUser1" "!selfFireUser15-1"
 }
 
 modify:
@@ -1388,7 +1390,7 @@ modify:
     {
         "OnTrigger" "chapter_gametextAddOutputcolor 255 255 091"
         "OnTrigger" "chapter_gametextAddOutputmessage << EARTH >>9.11"
-        "OnTrigger" "chapter_gametextDisplay9.21"
+        "OnTrigger" "chapter_gametextFireUser19.21"
     }
 }
 
@@ -1402,7 +1404,7 @@ modify:
     {
         "OnTrigger" "chapter_gametextAddOutputcolor 0 255 25591"
         "OnTrigger" "chapter_gametextAddOutputmessage << WATER >>9.11"
-        "OnTrigger" "chapter_gametextDisplay9.21"
+        "OnTrigger" "chapter_gametextFireUser19.21"
     }
 }
 
@@ -1416,7 +1418,7 @@ modify:
     {
         "OnTrigger" "chapter_gametextAddOutputcolor 0 255 091"
         "OnTrigger" "chapter_gametextAddOutputmessage << WIND >>9.11"
-        "OnTrigger" "chapter_gametextDisplay9.21"
+        "OnTrigger" "chapter_gametextFireUser19.21"
     }
 }
 
@@ -1430,7 +1432,7 @@ modify:
     {
         "OnTrigger" "chapter_gametextAddOutputcolor 255 0 091"
         "OnTrigger" "chapter_gametextAddOutputmessage << FIRE >>9.11"
-        "OnTrigger" "chapter_gametextDisplay9.21"
+        "OnTrigger" "chapter_gametextFireUser19.21"
     }
 }
 
@@ -1444,7 +1446,7 @@ modify:
     {
         "OnTrigger" "chapter_gametextAddOutputcolor 255 255 2551801"
         "OnTrigger" "chapter_gametextAddOutputmessage << PHILIA >>180.11"
-        "OnTrigger" "chapter_gametextDisplay180.21"
+        "OnTrigger" "chapter_gametextFireUser1180.21"
     }
 }
 


### PR DESCRIPTION
CS:GO has a bug where `game_text` entity with high holdtime will bug out and cause other `game_text` channels to flicker. Changing the game text to display itself on a loop resolves flickering. This system is what I used in Deadcore for displaying the stage text as well.